### PR TITLE
Specs for generators

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,3 +23,26 @@ namespace :db do
     ActiveRecord::Base.logger = Logger.new(File.open('db/database.log', 'a')) 
   end
 end
+
+namespace :generate do
+  desc "generate a fresh app with rspec installed"
+  task :app do |t|
+    unless File.directory?('./tmp/example_app')
+      sh "rails new ./tmp/example_app --skip-javascript --skip-gemfile --skip-git"
+      bindir = File.expand_path("bin")
+      if test ?d, bindir
+        Dir.chdir("./tmp/example_app") do
+          sh "rm -rf test"
+          sh "ln -s #{bindir}"
+          application_file = File.read("config/application.rb")
+          sh "rm config/application.rb"
+          File.open("config/application.rb","w") do |f|
+            f.write application_file.gsub("config.assets.enabled = true","config.assets.enabled = false")
+          end
+        end
+      end
+    end
+  end
+end
+
+task :rspec => 'generate:app'

--- a/Rakefile
+++ b/Rakefile
@@ -45,4 +45,4 @@ namespace :generate do
   end
 end
 
-task :rspec => 'generate:app'
+task :spec => 'generate:app'

--- a/footprint.gemspec
+++ b/footprint.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency  "factory_girl"
   gem.add_development_dependency  "sqlite3"
   gem.add_development_dependency  "ammeter"
+  gem.add_development_dependency  "rails"
   
   gem.add_dependency              "mongoid", "~> 3.0"
   gem.add_dependency              "activerecord", "~> 3.2.0"

--- a/spec/generators/rspec/document/document_generator_spec.rb
+++ b/spec/generators/rspec/document/document_generator_spec.rb
@@ -4,16 +4,24 @@ require "spec_helper"
 require 'generators/footprint/document/document_generator'
 
 describe Footprint::Generators::DocumentGenerator do
-  destination File.expand_path("../../../../../tmp", __FILE__)
-  before { prepare_destination }
-  
+  destination File.expand_path("../../../../../tmp/sample", __FILE__)
+
+  before do
+    prepare_destination
+
+    example_app = File.expand_path("../../../../../tmp/example_app", __FILE__)
+    %w(config script).each do |dir|
+      `ln -s #{example_app + '/' + dir} #{destination_root}`
+    end
+    `mkdir -p #{destination_root}/app/models`
+  end
+
   describe "with valid ActiveRecord model" do
     describe "generates a document" do
-      # run_generator %w(Yeti)
-      # subject { file('app/models/yeti_footprint.rb') }
-      #it { should exist }
-      # TODO Fix problem of 'scope/rails' not found in spec
-      it "needs a fix problem 'script/rails' not found"
+      before { run_generator %w(Yeti) }
+      subject { file('app/models/yeti_footprint.rb') }
+      it { should exist }
+      it { should contain 'class YetiFootprint < Footprint::Impression'}
     end
   end
 end

--- a/spec/generators/rspec/install/install_generator_spec.rb
+++ b/spec/generators/rspec/install/install_generator_spec.rb
@@ -2,11 +2,23 @@ require "spec_helper"
 require 'generators/footprint/install/install_generator'
 
 describe Footprint::Generators::InstallGenerator do
-  destination File.expand_path("../../../../../tmp", __FILE__)
-  before { prepare_destination }
-  
+  destination File.expand_path("../../../../../tmp/sample", __FILE__)
+  before do
+    prepare_destination
+
+    example_app = File.expand_path("../../../../../tmp/example_app", __FILE__)
+    %w(script).each do |dir|
+      `ln -s #{example_app + '/' + dir} #{destination_root}`
+    end
+    `mkdir #{destination_root}/config`
+    Dir["#{example_app}/config/*"].each do |dir|
+      `ln -s #{dir} #{destination_root}/config`
+    end
+  end
+
   describe "generates mongoid configuration" do
-    # TODO Fix problem of 'scope/rails' not found in spec
-    it "needs a fix problem 'script/rails' not found"
+    before { run_generator }
+    subject { file('config/mongoid.yml') }
+    it { should exist }
   end
 end


### PR DESCRIPTION
To run the generators a full rails app is required because they run 'scripts/rails' and assume the rails directory structure.
Before running the specs one is generated in 'tmp/example_app' and each generator spec links to it in tmp/sample.
